### PR TITLE
bugfix: handle empty repo-specific CODEOWNERS rules & fallback to org reviewers

### DIFF
--- a/.github/workflows/assign_reviewers.yaml
+++ b/.github/workflows/assign_reviewers.yaml
@@ -75,9 +75,9 @@ jobs:
           all_rules=$(grep -v '^#\|^$' "$CODEOWNERS_PATH")
 
           # Extract repo-specific rules
-          repo_specific_rules=$(echo "$all_rules" | grep -E "^/$CURRENT_REPO/")
+          repo_specific_rules=$(echo "$all_rules" | grep -E "^/$CURRENT_REPO/" || true)
           # Extract global rules
-          org_root_rules=$(echo "$all_rules" | grep -E '^/\.[[:space:]]+@')
+          org_root_rules=$(echo "$all_rules" | grep -E '^/\.[[:space:]]+@' || true)
 
           # Extract orgnization owners
           org_owners=$(echo "$org_root_rules" | sed -E 's|^/\.[[:space:]]+@?||; s/[[:space:]]+$//' | tr ' ' '\n' | sort -u)
@@ -113,16 +113,17 @@ jobs:
             echo -e "\n=== Processing Repository-Specific Rules ==="
             # Directly extract owners from top-level repo rules (e.g., /repo-a/ @user1 @user2)
             repo_owners_str=$(echo "$repo_specific_rules" |
-              sed -E "s|^/$CURRENT_REPO/[[:space:]]*||" |  # Remove "/repo-a/" prefix
-              tr -s ' ' '\n' |                             # Split owners into lines
-              grep -E '^@' |                               # Keep only @-prefixed entries
-              sed 's/^@//')                                # Remove @ symbol
+              sed -E "s|^/$CURRENT_REPO/[[:space:]]*||" |
+              tr -s ' ' '\n' |
+              grep -E '^@' |
+              sed 's/^@//')
 
-            # Populate associative array (auto-deduplicate)
             for owner in $repo_owners_str; do
               repo_owners["$owner"]=1
               echo "Found repo owner: $owner"
             done
+          else
+            echo -e "\n=== No Repository-Specific Rules Found for $CURRENT_REPO ==="
           fi
 
           # ======================


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉
Please make sure your pull request follows the contribution standards so the review and merge process can go smoothly.
-->

# Description
<!--
Briefly describe the purpose of this PR — what it does, why it’s needed, and which issue(s) it addresses.
Use “Fixes #<issue_number>” if applicable.
-->

Fix workflow failure when no repository-specific CODEOWNERS rules exist (e.g., for the .github repo) by adding fault tolerance and conditional logic. Ensure the workflow falls back to org-level reviewers as intended.

# Changes
<!--
Summarize key modifications — new features, bug fixes, refactors, or documentation updates.
-->

- Added || true to grep commands for extracting CODEOWNERS rules (repo-specific + global) to allow empty matches without script termination
- Added conditional check for non-empty repo_specific_rules before processing repository-specific owners
- Added informative log message when no repo-specific rules are found (clarifies fallback to org owners)
- Maintained core reviewer assignment logic and org-level fallback guarantee


# Testing & Benchmark
<!--
If applicable, include test results (e.g., unit tests, accuracy verification, performance benchmarks).
Please attach **logs, screenshots or reports** demonstrating that the code runs successfully and produces the expected results.
-->

# Checklist

- [x] Read and followed the [Contributing Guidelines](https://github.com/mindspore-courses/.github/blob/master/docs/wiki/Contributing-Guidelines.md).
- [x] Self-tested locally to ensure the code runs correctly and achieves expected results (all CI checks expected to pass).
- [x] Updated documentation if needed.
- [ ] Verified accuracy or performance benchmarks if applicable.

# Reviewers
<!--
Please note: each PR must be reviewed by at least **two committers** once all tests have passed.
You may optionally tag members or contributors who might be interested in your PR.
-->
