### PR TITLE
fix(workflow): resolve unbound variable error & clean @ symbols in org owners

### DIFF
--- a/.github/workflows/assign_reviewers.yaml
+++ b/.github/workflows/assign_reviewers.yaml
@@ -80,7 +80,7 @@ jobs:
           org_root_rules=$(echo "$all_rules" | grep -E '^/\.[[:space:]]+@' || true)
 
           # Extract orgnization owners
-          org_owners=$(echo "$org_root_rules" | sed -E 's|^/\.[[:space:]]+@?||; s/[[:space:]]+$//' | tr ' ' '\n' | sort -u)
+          org_owners=$(echo "$org_root_rules" | sed -E 's|^/\.[[:space:]]+@?||; s/[[:space:]]+$//' | tr ' ' '\n' | sed 's/^@//' | sort -u)
           if [ -z "$org_owners" ]; then
             echo "Error: No org fallback owners found in CODEOWNERS (expect: /. @org-owner1 [@org-owner2 ...])"
             exit 1
@@ -108,6 +108,7 @@ jobs:
           # ======================
 
           declare -A repo_owners
+          : ${repo_owners:=()}
 
           if [ -n "$repo_specific_rules" ]; then
             echo -e "\n=== Processing Repository-Specific Rules ==="


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉
Please make sure your pull request follows the contribution standards so the review and merge process can go smoothly.
-->

# Description
<!--
Briefly describe the purpose of this PR — what it does, why it’s needed, and which issue(s) it addresses.
Use “Fixes #<issue_number>” if applicable.
-->

Fix two critical issues in the auto-assign reviewers workflow: unbound repo_owners variable error under set -u and residual @ symbols in org fallback owners. Ensure smooth fallback to org-level reviewers when no repo-specific CODEOWNERS rules exist.

# Changes
<!--
Summarize key modifications — new features, bug fixes, refactors, or documentation updates.
-->

Added explicit fallback initialization for repo_owners array with : ${repo_owners:=()} to eliminate unbound variable errors (even in edge cases)
Enhanced org_owners extraction logic by adding sed 's/^@//' to strip residual @ symbols from org-level reviewer names

# Testing & Benchmark
<!--
If applicable, include test results (e.g., unit tests, accuracy verification, performance benchmarks).
Please attach **logs, screenshots or reports** demonstrating that the code runs successfully and produces the expected results.
-->

# Checklist

- [x] Read and followed the [Contributing Guidelines](https://github.com/mindspore-courses/.github/blob/master/docs/wiki/Contributing-Guidelines.md).
- [x] Self-tested locally to ensure the code runs correctly and achieves expected results (all CI checks expected to pass).
- [x] Updated documentation if needed.
- [x] Verified accuracy or performance benchmarks if applicable.

# Reviewers
<!--
Please note: each PR must be reviewed by at least **two committers** once all tests have passed.
You may optionally tag members or contributors who might be interested in your PR.
-->
